### PR TITLE
Use Non-AMD Version of Backbone

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,16 +42,14 @@ requirejs.config({
       backbone: 'vendor/backbone-0.9.2'
     },
     shim: {
-      'backbone': {
+      backbone: {
         deps: ['underscore', 'jquery'], 
         exports: 'Backbone'
       },
-      'underscore' :{
+      underscore :{
         exports: '_'
       }
     },
-
-
     waitSeconds: 1,
     // For easier development, disable browser caching
     // Of course, this should be removed in a production environment

--- a/js/vendor/backbone-0.9.2.js
+++ b/js/vendor/backbone-0.9.2.js
@@ -5,26 +5,14 @@
 //     For all details and documentation:
 //     http://backbonejs.org
 
-(function(root, factory) {
-  // Set up Backbone appropriately for the environment.
-  if (typeof exports !== 'undefined') {
-    // Node/CommonJS, no need for jQuery in that case.
-    factory(root, exports, require('underscore'));
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD
-    define(['underscore', 'jquery', 'exports'], function(_, $, exports) {
-      // Export global even in AMD case in case this script is loaded with
-      // others that may still expect a global Backbone.
-      root.Backbone = factory(root, exports, _, $);
-    });
-  } else {
-    // Browser globals
-    root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender));
-  }
-}(this, function(root, Backbone, _, $) {
+(function(){
 
   // Initial Setup
   // -------------
+
+  // Save a reference to the global object (`window` in the browser, `global`
+  // on the server).
+  var root = this;
 
   // Save the previous value of the `Backbone` variable, so that it can be
   // restored later on, if `noConflict` is used.
@@ -34,8 +22,24 @@
   var slice = Array.prototype.slice;
   var splice = Array.prototype.splice;
 
+  // The top-level namespace. All public Backbone classes and modules will
+  // be attached to this. Exported for both CommonJS and the browser.
+  var Backbone;
+  if (typeof exports !== 'undefined') {
+    Backbone = exports;
+  } else {
+    Backbone = root.Backbone = {};
+  }
+
   // Current version of the library. Keep in sync with `package.json`.
   Backbone.VERSION = '0.9.2';
+
+  // Require Underscore, if we're on the server, and it's not already present.
+  var _ = root._;
+  if (!_ && (typeof require !== 'undefined')) _ = require('underscore');
+
+  // For Backbone's purposes, jQuery, Zepto, or Ender owns the `$` variable.
+  var $ = root.jQuery || root.Zepto || root.ender;
 
   // Set the JavaScript library that will be used for DOM manipulation and
   // Ajax calls (a.k.a. the `$` variable). By default Backbone will use: jQuery,
@@ -50,7 +54,7 @@
   // to its previous owner. Returns a reference to this Backbone object.
   Backbone.noConflict = function() {
     root.Backbone = previousBackbone;
-    return Backbone;
+    return this;
   };
 
   // Turn on `emulateHTTP` to support legacy HTTP servers. Setting this option
@@ -1188,7 +1192,7 @@
     make: function(tagName, attributes, content) {
       var el = document.createElement(tagName);
       if (attributes) $(el).attr(attributes);
-      if (content != null) $(el).html(content);
+      if (content) $(el).html(content);
       return el;
     },
 
@@ -1424,5 +1428,4 @@
     throw new Error('A "url" property or function must be specified');
   };
 
-  return Backbone;
-}));
+}).call(this);


### PR DESCRIPTION
Didn't know that chaplin was using a modified version of backbone at the time of last commit.  This should now be the vanilla backbone.js and using the shim to load.
